### PR TITLE
Separate flask session from DB session

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,7 +3,7 @@ from functools import wraps
 from flask import Flask, render_template, send_file, request, session, redirect, url_for
 
 from user_database import CITIES, MONTHS, data, get_city_temperature, get_city_humidity
-from user_database import session as db_session
+from user_database import db_session
 from charts import get_city_image, get_main_image
 
 app = Flask(__name__)

--- a/user_database.py
+++ b/user_database.py
@@ -6,7 +6,7 @@ metadata = MetaData()
 # ToDo: do not use check_same_thread
 engine = create_engine('sqlite:///user_database', connect_args={'check_same_thread': False}, echo=False)  # echo=False
 Base = declarative_base()
-session = sessionmaker(bind=engine)()
+db_session = sessionmaker(bind=engine)()
 
 
 # Table city
@@ -31,7 +31,7 @@ class Meteo(Base):
 
 # Retrieving data from the database
 def get_cities():
-    return session.query(City)
+    return db_session.query(City)
 
 
 # ToDo: type annotations


### PR DESCRIPTION
Tutorial suggests to

>Use the `⌥⏎` shortcut to add the missing import statements

a lot and there is a good chance the wrong `session` will be imported into `app.py` - instead of `flask.session` PyCharm will suggest `user_database.session` as the first choice. Such an error will lead to a broken login, I faced it myself following the tutorial for the first time.

Lets rename `user_database.session` to `user_database.db_session` to prevent such confusion in the first place.