### PR TITLE
Do not show None on the login page if no error

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -15,7 +15,9 @@
                value="{{ request.form.password }}">
         <input class="btn btn-default" type="submit" value="Login">
     </form>
-    <p>{{ error }}</p>
+    {% if error is not none %}
+        <p>{{ error }} </p>
+    {% endif %}
 </div>
 </body>
 </html>


### PR DESCRIPTION
Login error is shown on the page even if it is `None`.

<img width="397" alt="none" src="https://user-images.githubusercontent.com/2500320/51074171-c94cd900-168c-11e9-8038-c4e209902e37.png">